### PR TITLE
Fixed typo text in cypress section of onboarding.md, Fixes #4

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -175,7 +175,7 @@ The Cypress end-to-end test framework works by controlling the web browser. A te
 
 Cypress component tests work by mounting a Vue Component into a browser and allowing tests to interact with it in isolation from the application.  A typical comonent test will:
   1. Configuring and mounting the component into the test framework.
-  1. Query the component for an _html element_ of interest (e.g. button, ext field)
+  1. Query the component for an _html element_ of interest (e.g. button, text field)
   1. Interact with that element (e.g. click the button, enter some text)
   1. Make an assertion about the result (e.g. the component emits an event or changes state).
 


### PR DESCRIPTION
__Pull Request Description__

In the cypress section of onboarding.md there was a typo on line 178 : 
1. Query the component for an _html element_ of interest (e.g. button, ext field)

The typo is at the end of the line within the brackets(ext field). 
Corrected to "text field)"

Fixes #4

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
